### PR TITLE
V4tov3

### DIFF
--- a/supportv4/detect.go
+++ b/supportv4/detect.go
@@ -1,8 +1,7 @@
 package supportv4
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/wcl48/gasegment"
 )
 
@@ -35,7 +34,7 @@ func DetectMatchType(stepType gasegment.SequenceStepType) (string, error) {
 	case gasegment.ImmediatelyPrecedes:
 		return MatchTypeImmediatelyPrecedes, nil
 	default:
-		return "", fmt.Errorf("unspecified match type: %v", stepType)
+		return "", errors.Errorf("unspecified match type: %v", stepType)
 	}
 }
 
@@ -61,7 +60,7 @@ func DetectScope(metricScope gasegment.MetricScope) (string, error) {
 	case gasegment.PerUser:
 		return ScopeUser, nil
 	default:
-		return "", fmt.Errorf("unspecified scope: %v", metricScope)
+		return "", errors.Errorf("unspecified scope: %v", metricScope)
 	}
 }
 
@@ -125,7 +124,7 @@ func DetectOperatorOnMetric(op gasegment.Operator) (opStr string, not bool, err 
 	// case gasegment.Regexp:
 	// case gasegment.NotRegexp:
 	default:
-		return "", false, fmt.Errorf("unspecified operator on metric %v", op)
+		return "", false, errors.Errorf("unspecified operator on metric %v", op)
 	}
 }
 
@@ -206,7 +205,7 @@ func DetectOperatorOnDimension(op gasegment.Operator) (opStr string, not bool, e
 	case gasegment.NotRegexp:
 		return OperatorRegexp, true, nil
 	default:
-		return "", false, fmt.Errorf("unspecified operator on dimension %v", op)
+		return "", false, errors.Errorf("unspecified operator on dimension %v", op)
 	}
 }
 
@@ -254,7 +253,7 @@ func DetectFilterType(dm gasegment.DimensionOrMetric) (FilterType, error) {
 		return ftype, err
 	}
 	if ftype == FilterTypeUnspecified {
-		return ftype, fmt.Errorf("unspecified filter type %v", dm)
+		return ftype, errors.Errorf("unspecified filter type %v", dm)
 	}
 	return ftype, nil
 }

--- a/supportv4/detect.go
+++ b/supportv4/detect.go
@@ -82,6 +82,7 @@ const (
 	OperatorNumericLessThan    = "NUMERIC_LESS_THAN"
 	OperatorNumericGreaterThan = "NUMERIC_GREATER_THAN"
 	OperatorNumericBetween     = "NUMERIC_BETWEEN"
+	OperatorNumericEquals      = "NUMERIC_EQUALS"
 )
 
 // DetectOperatorOnMetric :

--- a/supportv4/transform.go
+++ b/supportv4/transform.go
@@ -1,9 +1,9 @@
 package supportv4
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/wcl48/gasegment"
 	gapi "google.golang.org/api/analyticsreporting/v4"
 )
@@ -35,7 +35,7 @@ func TransformSegments(segments *gasegment.Segments) (*gapi.DynamicSegment, erro
 			}
 			sessionSegmentFilters = append(sessionSegmentFilters, segmentFilter)
 		default:
-			return nil, fmt.Errorf("cannot guess segment scope=%v", segment.Scope)
+			return nil, errors.Errorf("cannot guess segment scope=%v", segment.Scope)
 		}
 	}
 
@@ -86,7 +86,7 @@ func TransformSegment(segment *gasegment.Segment) (*gapi.DynamicSegment, error) 
 			},
 		}, nil
 	default:
-		return nil, fmt.Errorf("cannot guess segment scope=%v", segment.Scope)
+		return nil, errors.Errorf("cannot guess segment scope=%v", segment.Scope)
 	}
 }
 
@@ -101,7 +101,7 @@ func NewSegmentFilter(segment *gasegment.Segment) (*gapi.SegmentFilter, error) {
 	case gasegment.SequenceSegment:
 		return TransformSequence(&segment.Sequence)
 	default:
-		return nil, fmt.Errorf("cannot guess segment type=%v", segment.Type)
+		return nil, errors.Errorf("cannot guess segment type=%v", segment.Type)
 	}
 }
 
@@ -233,7 +233,7 @@ func TransformExpression(expr *gasegment.Expression) (*gapi.SegmentFilterClause,
 	case FilterTypeMetric:
 		return NewMetricFilterClause(expr)
 	default:
-		return nil, fmt.Errorf("cannot guess expression=%v", ftype)
+		return nil, errors.Errorf("cannot guess expression=%v", ftype)
 	}
 }
 
@@ -251,7 +251,7 @@ func NewDimensionFilterClause(expr *gasegment.Expression) (*gapi.SegmentFilterCl
 		// between operator "<>{minvalue}_{maxvalue}" (see: https://developers.google.com/analytics/devguides/reporting/core/v3/segments?hl=ja)
 		vs := strings.SplitN(expr.Value, "_", 2)
 		if len(vs) != 2 {
-			return nil, fmt.Errorf("required format is '<>{min_value}_{max_value}', but %q", expr.Value)
+			return nil, errors.Errorf("required format is '<>{min_value}_{max_value}', but %q", expr.Value)
 		}
 		return &gapi.SegmentFilterClause{
 			Not: not,
@@ -304,7 +304,7 @@ func NewMetricFilterClause(expr *gasegment.Expression) (*gapi.SegmentFilterClaus
 		// between operator "<>{minvalue}_{maxvalue}" (see: https://developers.google.com/analytics/devguides/reporting/core/v3/segments?hl=ja)
 		vs := strings.SplitN(expr.Value, "_", 2)
 		if len(vs) != 2 {
-			return nil, fmt.Errorf("required format is '<>{min_value}_{max_value}', but %q", expr.Value)
+			return nil, errors.Errorf("required format is '<>{min_value}_{max_value}', but %q", expr.Value)
 		}
 		return &gapi.SegmentFilterClause{
 			Not: not,

--- a/supportv4/transform.go
+++ b/supportv4/transform.go
@@ -300,6 +300,10 @@ func NewMetricFilterClause(expr *gasegment.Expression) (*gapi.SegmentFilterClaus
 	if err != nil {
 		return nil, err
 	}
+	scope, err := DetectScope(expr.MetricScope)
+	if err != nil {
+		return nil, err
+	}
 	if expr.Operator == gasegment.Between {
 		// between operator "<>{minvalue}_{maxvalue}" (see: https://developers.google.com/analytics/devguides/reporting/core/v3/segments?hl=ja)
 		vs := strings.SplitN(expr.Value, "_", 2)
@@ -309,6 +313,7 @@ func NewMetricFilterClause(expr *gasegment.Expression) (*gapi.SegmentFilterClaus
 		return &gapi.SegmentFilterClause{
 			Not: not,
 			MetricFilter: &gapi.SegmentMetricFilter{
+				Scope: scope,
 				// CaseSensitive false, // bool `json:"caseSensitive,omitempty"`
 				MetricName:         expr.Target.String(),
 				Operator:           op,
@@ -320,6 +325,7 @@ func NewMetricFilterClause(expr *gasegment.Expression) (*gapi.SegmentFilterClaus
 	return &gapi.SegmentFilterClause{
 		Not: not,
 		MetricFilter: &gapi.SegmentMetricFilter{
+			Scope: scope,
 			// CaseSensitive false, // bool `json:"caseSensitive,omitempty"`
 			MetricName:      expr.Target.String(),
 			Operator:        op,

--- a/supportv4/v3stringify.go
+++ b/supportv4/v3stringify.go
@@ -1,0 +1,144 @@
+package supportv4
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	gapi "google.golang.org/api/analyticsreporting/v4"
+)
+
+// V4[AST] -> V3[string]
+
+// V3StringifySegmentFilterClause :
+func V3StringifySegmentFilterClause(node *gapi.SegmentFilterClause) (string, error) {
+	if node.DimensionFilter != nil {
+		return V3StringifySegmentDimensionFilter(node.DimensionFilter, node.Not)
+	}
+	if node.MetricFilter != nil {
+		return V3StringifySegmentMetricFilter(node.MetricFilter, node.Not)
+	}
+	return "", errors.New("must be wither a metric or a dimension filter")
+}
+
+// V3StringifySegmentDimensionFilter :
+func V3StringifySegmentDimensionFilter(node *gapi.SegmentDimensionFilter, not bool) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+
+	// "OPERATOR_UNSPECIFIED" - If the match type is unspecified, it is treated as a REGEXP.
+	op := node.Operator
+	if op == "OPERATOR_UNSPECIFIED" || op == "" {
+		op = OperatorRegexp
+	}
+	if len(node.Expressions) == 0 {
+		return "", errors.New("invalid expression. at least length >= 1")
+	}
+	// see also: ./detect.go DetectOperatorOnDimension
+
+	// TODO: node.CaseSensitive
+	switch op {
+	case OperatorRegexp:
+		if not {
+			return fmt.Sprintf("%s!~%s", node.DimensionName, node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s=~%s", node.DimensionName, node.Expressions[0]), nil
+	case OperatorBeginsWith:
+		// TODO: need regex.QuoteMeta() ?
+		if not {
+			return fmt.Sprintf("%s!~%s", node.DimensionName, "^"+node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s=~%s", node.DimensionName, "^"+node.Expressions[0]), nil
+	case OperatorEndsWith:
+		if not {
+			return fmt.Sprintf("%s!~%s", node.DimensionName, node.Expressions[0]+"$"), nil
+		}
+		return fmt.Sprintf("%s=~%s", node.DimensionName, node.Expressions[0]+"$"), nil
+	case OperatorPartial:
+		if not {
+			return fmt.Sprintf("%s!@%s", node.DimensionName, node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s=@%s", node.DimensionName, node.Expressions[0]), nil
+	case OperatorExact, OperatorNumericEquals:
+		if not {
+			return fmt.Sprintf("%s!=%s", node.DimensionName, node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s==%s", node.DimensionName, node.Expressions[0]), nil
+	case OperatorInList:
+		// TODO: limitation of number of expressions <= 10
+		// TODO: need escape?
+		if not {
+			return "", fmt.Errorf("not support %q with Not=true", OperatorInList)
+		}
+		return fmt.Sprintf("%s[]%s", node.DimensionName, strings.Join(node.Expressions, "|")), nil
+	case OperatorNumericLessThan:
+		if not {
+			return fmt.Sprintf("%s>=%s", node.DimensionName, node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s<%s", node.DimensionName, node.Expressions[0]), nil
+	case OperatorNumericGreaterThan:
+		if not {
+			return fmt.Sprintf("%s<=%s", node.DimensionName, node.Expressions[0]), nil
+		}
+		return fmt.Sprintf("%s>%s", node.DimensionName, node.Expressions[0]), nil
+	case OperatorNumericBetween:
+		if not {
+			return "", fmt.Errorf("not support %q with Not=true", OperatorNumericBetween)
+		}
+		return fmt.Sprintf("%s<>%s_%s", node.DimensionName, node.Expressions[0], node.Expressions[1]), nil
+	default:
+		return "", fmt.Errorf("unsupported dimension operator: %s", op)
+	}
+}
+
+// V3StringifySegmentMetricFilter :
+func V3StringifySegmentMetricFilter(node *gapi.SegmentMetricFilter, not bool) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+
+	// TODO: node.Scope
+	// "OPERATOR_UNSPECIFIED" - If the match type is unspecified, it is treated as a REGEXP.
+	op := node.Operator
+	if op == "OPERATOR_UNSPECIFIED" {
+		op = OperatorEqual
+	}
+	// see also: ./detect.go DetectOperatorOnMetric
+
+	scopePrefix := ""
+	switch node.Scope {
+	case "PRODUCT":
+		scopePrefix = "perProduct::" // Product scope.
+	case "HIT":
+		scopePrefix = "perHit::" // Hit scope.
+	case "USER":
+		scopePrefix = "perUser::" // User scope.
+	case "SESSION":
+		scopePrefix = "perSession::" // Session scope.
+	}
+	switch op {
+	case OperatorEqual:
+		if not {
+			return fmt.Sprintf("%s%s!=%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+		}
+		return fmt.Sprintf("%s%s==%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+	case OperatorLessThan:
+		if not {
+			return fmt.Sprintf("%s%s>=%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+		}
+		return fmt.Sprintf("%s%s<%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+	case OperatorGreaterThan:
+		if not {
+			return fmt.Sprintf("%s%s<=%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+		}
+		return fmt.Sprintf("%s%s>%s", scopePrefix, node.MetricName, node.ComparisonValue), nil
+	case OperatorBetween:
+		if not {
+			return "", fmt.Errorf("not support %q with Not=true", OperatorBetween)
+		}
+		return fmt.Sprintf("%s%s<>%s_%s", scopePrefix, node.MetricName, node.ComparisonValue, node.MaxComparisonValue), nil
+	default:
+		return "", fmt.Errorf("unsupported metric operator: %s", op)
+	}
+}

--- a/supportv4/v3stringify.go
+++ b/supportv4/v3stringify.go
@@ -99,7 +99,6 @@ func V3StringifySequenceSegment(node *gapi.SequenceSegment) (string, error) {
 				bop = ";->"
 			}
 		}
-
 		// step.MatchType
 		inner := make([]string, 0, len(step.OrFiltersForSegment))
 		for _, orFilter := range step.OrFiltersForSegment {
@@ -180,7 +179,7 @@ func V3StringifySegmentDimensionFilter(node *gapi.SegmentDimensionFilter, not bo
 	if op == "OPERATOR_UNSPECIFIED" || op == "" {
 		op = OperatorRegexp
 	}
-	if len(node.Expressions) == 0 {
+	if len(node.Expressions) == 0 && op != OperatorNumericBetween {
 		return "", errors.New("invalid expression. at least length >= 1")
 	}
 	// see also: ./detect.go DetectOperatorOnDimension
@@ -232,7 +231,7 @@ func V3StringifySegmentDimensionFilter(node *gapi.SegmentDimensionFilter, not bo
 		if not {
 			return "", errors.Errorf("not support %q with Not=true", OperatorNumericBetween)
 		}
-		return fmt.Sprintf("%s<>%s_%s", node.DimensionName, node.Expressions[0], node.Expressions[1]), nil
+		return fmt.Sprintf("%s<>%s_%s", node.DimensionName, node.MinComparisonValue, node.MaxComparisonValue), nil
 	default:
 		return "", errors.Errorf("unsupported dimension operator: %s", op)
 	}

--- a/supportv4/v3stringify.go
+++ b/supportv4/v3stringify.go
@@ -10,8 +10,89 @@ import (
 
 // V4[AST] -> V3[string]
 
+// V3StringifyDynamicSegment :
+func V3StringifyDynamicSegment(node *gapi.DynamicSegment) (string, error) {
+	if node.SessionSegment != nil {
+		inner, err := V3StringifySegmentDefinition(node.SessionSegment)
+		if err != nil {
+			return "", err
+		}
+		return "sessions::" + inner, nil
+	}
+	if node.UserSegment != nil {
+		inner, err := V3StringifySegmentDefinition(node.UserSegment)
+		if err != nil {
+			return "", err
+		}
+		return "users::" + inner, nil
+	}
+	return "", errors.New("at least either a session or a user segment")
+}
+
+// V3StringifySegmentDefinition :
+func V3StringifySegmentDefinition(node *gapi.SegmentDefinition) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+	outer := make([]string, 0, len(node.SegmentFilters))
+	for _, segmentFilter := range node.SegmentFilters {
+		inner, err := V3StringifySegmentFilter(segmentFilter)
+		if err != nil {
+			return "", err
+		}
+		outer = append(outer, inner)
+	}
+	return strings.Join(outer, ";"), nil
+}
+
+// V3StringifySegmentFilter :
+func V3StringifySegmentFilter(node *gapi.SegmentFilter) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+	if node.SimpleSegment != nil {
+		inner, err := V3StringifySimpleSegment(node.SimpleSegment)
+		if err != nil {
+			return "", err
+		}
+		if node.Not {
+			inner = "!" + inner
+		}
+		return "conditions::" + inner, nil
+	}
+	if node.SequenceSegment != nil {
+		return "", errors.New("TODO")
+	}
+	return "", errors.New("at least either a simple or a sequence segment")
+}
+
+// V3StringifySimpleSegment :
+func V3StringifySimpleSegment(node *gapi.SimpleSegment) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+	outer := make([]string, 0, len(node.OrFiltersForSegment))
+	for _, orFilter := range node.OrFiltersForSegment {
+		inner := make([]string, 0, len(orFilter.SegmentFilterClauses))
+		for _, segmentFilter := range orFilter.SegmentFilterClauses {
+			expression, err := V3StringifySegmentFilterClause(segmentFilter)
+			if err != nil {
+				return "", err
+			}
+			inner = append(inner, expression)
+		}
+		if len(inner) > 0 {
+			outer = append(outer, strings.Join(inner, ","))
+		}
+	}
+	return strings.Join(outer, ";"), nil
+}
+
 // V3StringifySegmentFilterClause :
 func V3StringifySegmentFilterClause(node *gapi.SegmentFilterClause) (string, error) {
+	if node == nil {
+		return "", nil
+	}
 	if node.DimensionFilter != nil {
 		return V3StringifySegmentDimensionFilter(node.DimensionFilter, node.Not)
 	}

--- a/supportv4/v3stringify.go
+++ b/supportv4/v3stringify.go
@@ -2,6 +2,7 @@ package supportv4
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -205,14 +206,14 @@ func V3StringifySegmentDimensionFilter(node *gapi.SegmentDimensionFilter, not bo
 		return fmt.Sprintf("%s=~%s", node.DimensionName, node.Expressions[0]), nil
 	case OperatorBeginsWith:
 		if not {
-			return fmt.Sprintf("%s!~%s", node.DimensionName, "^"+node.Expressions[0]), nil
+			return fmt.Sprintf("%s!~%s", node.DimensionName, "^"+regexp.QuoteMeta(node.Expressions[0])), nil
 		}
-		return fmt.Sprintf("%s=~%s", node.DimensionName, "^"+node.Expressions[0]), nil
+		return fmt.Sprintf("%s=~%s", node.DimensionName, "^"+regexp.QuoteMeta(node.Expressions[0])), nil
 	case OperatorEndsWith:
 		if not {
-			return fmt.Sprintf("%s!~%s", node.DimensionName, node.Expressions[0]+"$"), nil
+			return fmt.Sprintf("%s!~%s", node.DimensionName, regexp.QuoteMeta(node.Expressions[0])+"$"), nil
 		}
-		return fmt.Sprintf("%s=~%s", node.DimensionName, node.Expressions[0]+"$"), nil
+		return fmt.Sprintf("%s=~%s", node.DimensionName, regexp.QuoteMeta(node.Expressions[0])+"$"), nil
 	case OperatorPartial:
 		if not {
 			return fmt.Sprintf("%s!@%s", node.DimensionName, node.Expressions[0]), nil

--- a/supportv4/v3stringify.go
+++ b/supportv4/v3stringify.go
@@ -12,21 +12,25 @@ import (
 
 // V3StringifyDynamicSegment :
 func V3StringifyDynamicSegment(node *gapi.DynamicSegment) (string, error) {
-	if node.SessionSegment != nil {
-		inner, err := V3StringifySegmentDefinition(node.SessionSegment)
-		if err != nil {
-			return "", err
-		}
-		return "sessions::" + inner, nil
-	}
+	statements := make([]string, 0, 2)
 	if node.UserSegment != nil {
 		inner, err := V3StringifySegmentDefinition(node.UserSegment)
 		if err != nil {
 			return "", err
 		}
-		return "users::" + inner, nil
+		statements = append(statements, "users::"+inner)
 	}
-	return "", errors.New("at least either a session or a user segment")
+	if node.SessionSegment != nil {
+		inner, err := V3StringifySegmentDefinition(node.SessionSegment)
+		if err != nil {
+			return "", err
+		}
+		statements = append(statements, "sessions::"+inner)
+	}
+	if len(statements) <= 0 {
+		return "", errors.New("at least either a session or a user segment")
+	}
+	return strings.Join(statements, ";"), nil
 }
 
 // V3StringifySegmentDefinition :

--- a/supportv4/v3stringify_test.go
+++ b/supportv4/v3stringify_test.go
@@ -28,7 +28,15 @@ func TestReversible(t *testing.T) {
 		"sessions::condition::ga:landingPagePath=~^example.com/blog/(xxx|yyy)/",
 		"sessions::condition::ga:landingPagePath=~^\\Qexample.com/blog/xxx\\E,ga:landingPagePath=~^\\Qexample.com/blog/yyy\\E",
 		"sessions::condition::ga:sessionCount>2;ga:sessionCount<>2_3;ga:hits>10;ga:hits<>10_100",
+		"sessions::condition::ga:sessionCount>2;ga:sessionCount<>foo\\_bar_end",
 		"users::sequence::ga:deviceCategory==desktop;->ga:deviceCategory==tablet",
+		"sessions::condition::ga:medium=~^(cpc|ppc|cpa|cpm|cpv|cpp|xx\\|xx)$",
+		"users::condition::!ga:pagePath=~^\\Q/recruit/\\E;sessions::condition::ga:deviceCategory=@desktop",
+		"users::condition::perSession::ga:goal3Completions!=0;condition::!ga:pagePath=~^\\Q/recruit/\\E;condition::ga:pagePath=~^\\Q/kpdf_app\\E;sessions::condition::ga:deviceCategory=@desktop",
+		"users::sequence::!ga:flashVersion=@bar2;sessions::condition::ga:flashVersion=@test\\,ga:flashVersion=@test3\\\\;ga:flashVersion=@and\\;\\,;condition::!ga:sessionDurationBucket==123;sequence::^ga:operatingSystem=@Windows",
+		"sessions::condition::ga:deviceCategory=@mobile;condition::ga:landingPagePath==sp.exampleonline.co.jp/exampleol/www.exampleonline.co.jp/mb/BSfMbCategoryTop.jsp\\;sjid=CB706677EAC2E584171A5582CC8275C6.c?bg=set&guid=on",
+		"sessions::condition::ga:deviceCategory=@desktop;condition::ga:pagePath=@embed,ga:pagePath==/files/embed/cartonbox.html,ga:pagePath=@/files/cp/kaitori,ga:pagePath=@/cd/files/kaitori1307,ga:pagePath==/files/selltop.html;ga:pagePath=@sell,ga:pagePath==/files/embed/cartonbox.html,ga:pagePath=@/files/cp/kaitori,ga:pagePath=@/cd/files/kaitori1307,ga:pagePath==/files/selltop.html",
+		"users::sequence::!^ga:pagePath==/aiueo;->ga:pagePath==/aiueo2;->>ga:pagePath==/aiueo3",
 	}
 
 	for i, defstring := range candidates {

--- a/supportv4/v3stringify_test.go
+++ b/supportv4/v3stringify_test.go
@@ -1,0 +1,46 @@
+package supportv4
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/wcl48/gasegment"
+)
+
+func fullTransform(defstring string) (string, error) {
+	// v3string -> gasegment -> v4ast -> v3string
+	segments, err := gasegment.Parse(defstring)
+	if err != nil {
+		return "", err
+	}
+	ds, err := TransformSegments(&segments)
+	if err != nil {
+		return "", err
+	}
+	return V3StringifyDynamicSegment(ds)
+}
+
+func TestReversible(t *testing.T) {
+	candidates := []string{
+		"sessions::condition::ga:medium==referral",
+		"users::condition::ga:sessions>10;sequence::ga:deviceCategory==desktop;->>ga:deviceCategory==mobile",
+		"sessions::condition::!ga:landingPagePath=~^\\Qexample.com/blog/xxx/\\E;condition::!ga:landingPagePath=~^\\Qexample.com/yyy/\\E",
+		"sessions::condition::ga:landingPagePath=~^example.com/blog/(xxx|yyy)/",
+		"sessions::condition::ga:landingPagePath=~^\\Qexample.com/blog/xxx\\E,ga:landingPagePath=~^\\Qexample.com/blog/yyy\\E",
+		"sessions::condition::ga:sessionCount>2;ga:sessionCount<>2_3;ga:hits>10;ga:hits<>10_100",
+		"users::sequence::ga:deviceCategory==desktop;->ga:deviceCategory==tablet",
+	}
+
+	for i, defstring := range candidates {
+		defstring := defstring
+		t.Run(fmt.Sprintf("reversible%d", i), func(t *testing.T) {
+			result, err := fullTransform(defstring)
+			if err != nil {
+				t.Fatalf("no error required in %q. but %v is occured", defstring, err)
+			}
+			if result != defstring {
+				t.Errorf("\nexpected:\n\t%q\ngot:\n\t%q", defstring, result)
+			}
+		})
+	}
+}

--- a/supportv4/v3stringify_test.go
+++ b/supportv4/v3stringify_test.go
@@ -39,7 +39,6 @@ func TestReversible(t *testing.T) {
 		"users::sequence::!^ga:pagePath==/aiueo;->ga:pagePath==/aiueo2;->>ga:pagePath==/aiueo3",
 		"users::sequence::!^ga:pagePath==/aiueo;->>ga:pagePath==/aiueo2;->ga:pagePath==/aiueo3",
 		"users::sequence::^ga:sessionCount==1;dateOfSession<>2014-05-20_2014-05-30;->>ga:sessionDurationBucket>600",
-		"sessions::condition::ga:pagePath"
 	}
 
 	for i, defstring := range candidates {

--- a/supportv4/v3stringify_test.go
+++ b/supportv4/v3stringify_test.go
@@ -37,6 +37,9 @@ func TestReversible(t *testing.T) {
 		"sessions::condition::ga:deviceCategory=@mobile;condition::ga:landingPagePath==sp.exampleonline.co.jp/exampleol/www.exampleonline.co.jp/mb/BSfMbCategoryTop.jsp\\;sjid=CB706677EAC2E584171A5582CC8275C6.c?bg=set&guid=on",
 		"sessions::condition::ga:deviceCategory=@desktop;condition::ga:pagePath=@embed,ga:pagePath==/files/embed/cartonbox.html,ga:pagePath=@/files/cp/kaitori,ga:pagePath=@/cd/files/kaitori1307,ga:pagePath==/files/selltop.html;ga:pagePath=@sell,ga:pagePath==/files/embed/cartonbox.html,ga:pagePath=@/files/cp/kaitori,ga:pagePath=@/cd/files/kaitori1307,ga:pagePath==/files/selltop.html",
 		"users::sequence::!^ga:pagePath==/aiueo;->ga:pagePath==/aiueo2;->>ga:pagePath==/aiueo3",
+		"users::sequence::!^ga:pagePath==/aiueo;->>ga:pagePath==/aiueo2;->ga:pagePath==/aiueo3",
+		"users::sequence::^ga:sessionCount==1;dateOfSession<>2014-05-20_2014-05-30;->>ga:sessionDurationBucket>600",
+		"sessions::condition::ga:pagePath"
 	}
 
 	for i, defstring := range candidates {

--- a/supportv4/v3stringify_test.go
+++ b/supportv4/v3stringify_test.go
@@ -52,3 +52,18 @@ func TestReversible(t *testing.T) {
 		})
 	}
 }
+
+func TestReversible2(t *testing.T) {
+	for i, defstring := range gasegment.TestCheckDefs {
+		defstring := defstring
+		t.Run(fmt.Sprintf("reversible%d", i), func(t *testing.T) {
+			result, err := fullTransform(defstring)
+			if err != nil {
+				t.Fatalf("no error required in %q. but %v is occured", defstring, err)
+			}
+			if result != defstring {
+				t.Errorf("\nexpected:\n\t%q\ngot:\n\t%q", defstring, result)
+			}
+		})
+	}
+}

--- a/validation_dimension_and_metric.go
+++ b/validation_dimension_and_metric.go
@@ -95,6 +95,22 @@ func init() {
 		}
 		dmDefMap[column.Id] = ca
 	}
+
+	// dateOfSession
+	{
+		ca := DimensionOrMetricAttributes{
+			Id:                "dateOfSession",
+			Type:              "DIMENSION",
+			DataType:          "STRING",
+			Group:             "__special__",
+			Status:            "PUBLIC",
+			UIName:            "Date Of Session",
+			AppUIName:         "Date Of Session",
+			Description:       "The date of session started",
+			AllowedInSegments: true,
+		}
+		dmDefMap[ca.Id] = ca
+	}
 }
 
 func GetDimensionOrMetricAttributes(dm string) (DimensionOrMetricAttributes, error) {


### PR DESCRIPTION
- conversion about v4[ast]  -> v3[string]
- using pkg/errors package
- fix bug -- on transform(gaesegment -> v4[ast]), metricScope is ignored